### PR TITLE
cpp header <cerrno>

### DIFF
--- a/multirom/cp_xattrs/libcp_xattrs.h
+++ b/multirom/cp_xattrs/libcp_xattrs.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <cerrno>
 
 bool cp_xattrs_single_file(const std::string& from, const std::string& to);
 bool cp_xattrs_recursive(const std::string& from, const std::string& to, unsigned char type);


### PR DESCRIPTION
bootable/recovery/multirom/cp_xattrs/libcp_xattrs.cpp:59:16: error: 'errno' was not declared in this scope
             if(errno == ENOENT)
